### PR TITLE
Add linux aarch64 wheel build support

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,11 +4,17 @@ on: workflow_dispatch
 
 jobs:
   build_wheels:
-    name: ${{ matrix.os }}
+    name: ${{ matrix.os }}, ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        arch: [auto, aarch64]
+        exclude:
+          - os: windows-latest
+            arch: aarch64
+          - os: macos-latest
+            arch: aarch64
 
     steps:
       - name: Checkout source
@@ -21,6 +27,10 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Setup QEMU
+        if: ${{ matrix.arch == 'aarch64' }}
+        uses: docker/setup-qemu-action@v1
+
       - name: Install cibuildwheel
         run: |
           python -m pip install cibuildwheel
@@ -28,6 +38,7 @@ jobs:
       - name: Build wheels
         env:
           CIBW_BUILD: "cp3?-*"
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BEFORE_ALL_LINUX: yum install -y libusb1-devel libudev-devel
         run: |


### PR DESCRIPTION
Package Owner: Disha Srivastava

PR change Details: Added linux aarch64 wheel support.

Testing Detail : logs: https://github.com/dishasrivastavapuresoftware/cython-hidapi/actions/runs/1101849993

Peer Reviewer: Madhukar

Reviewer: Pruthvi